### PR TITLE
Fixes JS isUpperCase example

### DIFF
--- a/src/assets/snippets/javascript/isUpperCase.md
+++ b/src/assets/snippets/javascript/isUpperCase.md
@@ -11,6 +11,6 @@ const isUpperCase = str => str === str.toUpperCase();
 
 ```js
 isUpperCase('ABC'); // true
-isLowerCase('A3@$'); // true
-isLowerCase('aB4'); // false
+isUpperCase('A3@$'); // true
+isUpperCase('aB4'); // false
 ```


### PR DESCRIPTION
The functions in the example code were incorrect. I switched them from `isLowerCase` to `isUpperCase`.