### PR TITLE
Fix link to flaticon.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ A big THANK YOU to these wonderful people!
 
 ###### Attributions
 
-- Icons/Graphic Elements [www.flaticon.com](www.flaticon.com)
+- Icons/Graphic Elements [www.flaticon.com](https://www.flaticon.com)
 - Javascript Snippets [30 seconds of code](https://github.com/30-seconds/30-seconds-of-code)
 - CSS Snippets [30 seconds of css](https://github.com/30-seconds/30-seconds-of-css)
 - interview Snippets [30 seconds of interviews](https://github.com/30-seconds/30-seconds-of-interviews)


### PR DESCRIPTION
Due to the format of the previous link, users are directed to  
`https://github.com/githubUserName/30_seconds_of_knowledge/blob/master/www.flaticon.com`.  
Now users will be directed to the [correct URL](https://www.flaticon.com/).